### PR TITLE
Fix an issue where assembly was too slow when using DS instructions

### DIFF
--- a/terminal_casl2comet2.js
+++ b/terminal_casl2comet2.js
@@ -1118,7 +1118,7 @@ function pass2(file, symtblp, memoryp, bufp) {
   }
 
   if (opt_a) {
-    outdump.push("\nDEFINED SYMBOLS\n");
+    outdump.push("\nDEFINED SYMBOLS");
     var where = [];
     for ( const key in symtblp ) {
       //outdump.push(key);
@@ -1142,7 +1142,7 @@ function pass2(file, symtblp, memoryp, bufp) {
         } else {
             label_view = `${marray[2]} (${marray[1]})`;
         }
-        outdump.push(`${symtblp[label]['line']}:\t${hex(expand_label( symtblp, label ),4)}\t${label_view}\n`);
+        outdump.push(`${symtblp[label]['line']}:\t${hex(expand_label( symtblp, label ),4)}\t${label_view}`);
       }
       
     }
@@ -1150,9 +1150,12 @@ function pass2(file, symtblp, memoryp, bufp) {
   } 
 
   if (opt_a) {
-    for (var i = 0; i < outdump.length; i++) {
-      caslprint(outdump[i]);
+    var outdump_buf = ""
+    for (var i = 0; i < outdump.length - 1; i++) {
+      outdump_buf += outdump[i] + "\n"
     }
+    outdump_buf += outdump[outdump.length - 1]
+    caslprint(outdump_buf);
   }
 }
 


### PR DESCRIPTION
# 変更点
caslprint()関数の呼び出し回数を1回にまとめました。
どうやら、terminaljsのprint()メソッドは呼び出すたびにその実行時間が長くなる性質があるようで、`DS 20000`のようにメモリをダンプする量が増えると指数関数的に実行時間が増大します。

# 懸念点
表示形式が崩れないように変更したつもりですが、テストをsample16.casのみしか行っていないため、他のファイルでちゃんとアセンプリの結果が表示されるかわかりません。