### PR TITLE
Fix bug that CASL2 shows null when there is no source in localStorage

### DIFF
--- a/casl2comet2js.html
+++ b/casl2comet2js.html
@@ -169,7 +169,10 @@
     </style>
     <script>
         window.onload = function () {
-            document.getElementById("casl2src").value = decodeURIComponent(localStorage.getItem('casl2src'));
+            var casl2src_item = localStorage.getItem('casl2src');
+            if (casl2src_item != null) {
+                document.getElementById("casl2src").value = decodeURIComponent(casl2src_item);
+            }
             var q = localStorage.getItem('quiet');
             if (q == 1) {
                 document.getElementById("quiet").checked = true;


### PR DESCRIPTION
# 問題点
localStorageにcasl2srcエントリが存在しないとき、CASL2エディタにnullと表示されてしまいます。
![image](https://user-images.githubusercontent.com/53329734/179174402-bee723dd-11f5-49de-ad7b-d063094a40d8.png)

# 変更点
localStorage#getItem()がnullを返すときは、エディタ要素への代入を行わないようにしました。