### PR TITLE
Absorb a difference in newline characters

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,18 +65,9 @@ jobs:
         run: python -m pip install -r requirements.txt
         working-directory: ./test
 
-      # pytest (all) を実行する
-      - name: Run Test not Windows
-        if: matrix.os != 'windows-latest'
+      # pytestを実行する
+      - name: Run Test
         run: python -m pytest -v --junit-xml result-${{ matrix.os }}.xml
-        working-directory: ./test
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # pytest (browserのみ) を実行する
-      - name: Run Test Windows
-        if: matrix.os == 'windows-latest'
-        run: python -m pytest -v --junit-xml result-${{ matrix.os }}.xml terminal_casl2comet2_test.py
         working-directory: ./test
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/c2c2.js
+++ b/c2c2.js
@@ -351,7 +351,7 @@ function pass1(source, symtblp, memoryp, bufp) {
   var address = 0;
   var literal_stack = [];
 
-  var lines = source.split('\n');
+  var lines = source.split(/\r\n|\n/);
   __line = 0;
   for (var i = 0; i < lines.length; i++) {
     __line++;


### PR DESCRIPTION
Windowsランナーでc2c2_test,pyがコケる問題（issue #20）を修正しました。

## #20の原因
Windows環境の改行文字の違いを吸収できていなかった

## 解決方法
Windows環境の改行文字の違いを吸収できるように正規表現を用いた